### PR TITLE
Allow webhost to allow download of SMZ3 Patch

### DIFF
--- a/WebHostLib/templates/macros.html
+++ b/WebHostLib/templates/macros.html
@@ -34,7 +34,7 @@
                         {% elif patch.game == "Ocarina of Time" %}
                         <a href="{{ url_for("download_slot_file", room_id=room.id, player_id=patch.player_id) }}" download>
                             Download APZ5 File...</a>
-                        {% elif patch.game in ["A Link to the Past", "Secret of Evermore", "Super Metroid"] %}
+                        {% elif patch.game in ["A Link to the Past", "Secret of Evermore", "Super Metroid", "SMZ3"] %}
                         <a href="{{ url_for("download_patch", patch_id=patch.id, room_id=room.id) }}" download>
                             Download Patch File...</a>
                         {% else %}


### PR DESCRIPTION
This change adds "SMZ3" to the macros.html file, allowing it to supply the 'apsmz' patch from a webhost instance.